### PR TITLE
Adding tzdata to the software list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN	apt-get update && apt-get install -y dotnet-sdk-2.0.0
 RUN	apt-get update && apt-get install -y redis-server
 
 # Install required software
-RUN	apt-get update && apt-get install -y libopus0 opus-tools libopus-dev libsodium-dev ffmpeg rsync python python3-pip
+RUN	apt-get update && apt-get install -y libopus0 opus-tools libopus-dev libsodium-dev ffmpeg rsync python python3-pip tzdata
 
 #Add youtube-dl
 RUN	curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl && chmod a+rx /usr/local/bin/youtube-dl


### PR DESCRIPTION
This allows for the .timezone command to be set to the preferred time instead of UTC. 

It also populates the .timezones list.